### PR TITLE
Fix to work with notify-send

### DIFF
--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -151,7 +151,7 @@ and 'mpg123' in linux"
                                                     "-sender" "org.gnu.Emacs"
                                                     "-message" message
                                                     "-ignoreDnD"))
-                    ((eq system-type 'gnu/linux) (list title message)))))
+                    ((eq system-type 'gnu/linux) (list "-u" "critical" title (concat message))))))
     (when (executable-find program)
       (apply 'start-process (append (list title nil program) args)))))
 

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -151,7 +151,7 @@ and 'mpg123' in linux"
                                                     "-sender" "org.gnu.Emacs"
                                                     "-message" message
                                                     "-ignoreDnD"))
-                    ((eq system-type 'gnu/linux) (list "-u" "critical" title (concat message))))))
+                    ((eq system-type 'gnu/linux) (list "-u" "critical" title message)))))
     (when (executable-find program)
       (apply 'start-process (append (list title nil program) args)))))
 


### PR DESCRIPTION
Thanks for making nice package.
I fix to work with notify-send.
I've added "-u" "critical" , so alarm-clock-system-notify will not disappear until alarm-clock user will click.
I'd like to use this feature, so please add it.

![screenshot from 2018-11-14 15-49-31](https://user-images.githubusercontent.com/19677939/48465541-79859900-e826-11e8-9482-78778640a70b.png)
