### PR TITLE
Windows system can play sound using mpg123

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An alarm clock for Emacs
 
 -   Emacs 24 or higher
 -   [mpg123](http://mpg123.org) (gnu/linux)
+-   [mpg123](http://mpg123.org) (windows)
 -   [terminal-notifier](https://github.com/julienXX/terminal-notifier) (macOS)
 -   [notify-send](https://manpages.debian.org/stretch/libnotify-bin/notify-send.1.en.html) (gnu/linux)
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ An alarm clock for Emacs
 ## Requirements
 
 -   Emacs 24 or higher
--   [mpg123](http://mpg123.org) (gnu/linux)
--   [mpg123](http://mpg123.org) (windows)
+-   [mpg123](http://mpg123.org) (gnu/linux & windows)
 -   [terminal-notifier](https://github.com/julienXX/terminal-notifier) (macOS)
 -   [notify-send](https://manpages.debian.org/stretch/libnotify-bin/notify-send.1.en.html) (gnu/linux)
 

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -245,9 +245,10 @@ MESSAGE will be shown when notifying in the status bar."
 (defun alarm-clock--ding ()
   "Play ding.
 In osx operating system, 'afplay' will be used to play sound,
-and 'mpg123' in linux"
+and 'mpg123' in linux or windows"
   (let ((program (cond ((eq system-type 'darwin) "afplay")
                        ((eq system-type 'gnu/linux) "mpg123")
+                       ((eq system-type 'windows-nt) "mpg123")
                        (t "")))
         (sound (expand-file-name alarm-clock-sound-file)))
     (when (and (executable-find program)


### PR DESCRIPTION
mpg123 can be installed using scoop
```
scoop bucket add extras
scoop install mpg123
```