### PR TITLE
fix: refactor path lookup for file

### DIFF
--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -43,7 +43,7 @@
 
 (defcustom alarm-clock-sound-file
   (concat
-   (file-name-directory (or load-file-name buffer-file-name))
+   (file-name-directory (locate-library "alarm-clock"))
    "alarm.mp3")
   "File to play the alarm sound."
   :type 'file


### PR DESCRIPTION
Changing the `alarm-clock-sound-file` throws an error. This refactor allows `Customize` to find the standard value later when it re-evaluates the expression.