### PR TITLE
Adding support for playing alarm sound for cygwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An alarm clock for Emacs
 ## Requirements
 
 -   Emacs 24 or higher
--   [mpg123](http://mpg123.org) (gnu/linux & windows)
+-   [mpg123](http://mpg123.org) (gnu/linux, Cygwin and Windows)
 -   [terminal-notifier](https://github.com/julienXX/terminal-notifier) (macOS)
 -   [notify-send](https://manpages.debian.org/stretch/libnotify-bin/notify-send.1.en.html) (gnu/linux)
 

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -249,6 +249,7 @@ and 'mpg123' in linux or windows"
   (let ((program (cond ((eq system-type 'darwin) "afplay")
                        ((eq system-type 'gnu/linux) "mpg123")
                        ((eq system-type 'windows-nt) "mpg123")
+                       ((eq system-type 'cygwin) "mpg123")
                        (t "")))
         (sound (expand-file-name alarm-clock-sound-file)))
     (when (and (executable-find program)


### PR DESCRIPTION
The mpg123 package is available on cygwin too, which allows a very simple fix for playing alarm sounds.