### PR TITLE
Reject past times

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,36 +5,42 @@
 
 An alarm clock for Emacs
 
+Derived from [wlemuel/alarm-clock](https://github.com/wlemuel/alarm-clock).
+
 ## Requirements
 
 -   Emacs 24 or higher
+-   [f](https://stable.melpa.org/#/f) file library; install with `(package-install 'f)
 -   [mpg123](http://mpg123.org) (gnu/linux)
 -   [terminal-notifier](https://github.com/julienXX/terminal-notifier) (macOS)
 -   [notify-send](https://manpages.debian.org/stretch/libnotify-bin/notify-send.1.en.html) (gnu/linux)
 
 ## Get started
 
--   Via [MELPA](https://melpa.org).
-
 -   Get alarm-clock
     -   Manually download alarm-clock and set-up your load path.
-
 -   To auto-start alarm-clock every time you open Emacs add these lines to your .emacs file:
 
-          (require 'alarm-clock) ; Not needed if you use package.el
+          (require 'alarm-clock)
 
 ## Basic Usage
 
 ### `alarm-clock-set`
 
-Set an alarm clock with the time following tips.  
-TIME can be "6"(6 seconds), "11 minutes", "10 hours", "11:40pm", etc.  
+Set an alarm clock with the time following tips.
+TIME can be "6"(6 seconds), "11 minutes", "10 hours", "11:40pm", etc.
 MESSAGE will be shown when notifying at setting time.
 
 ### `alarm-clock-list-view`
 
-Display the alarm clock list.  
-Use `a` to set a new alarm clock, `C-k` to delete current alarm clock.
+Display the alarm clock list.
+Use `a` to set a new alarm clock, `d` or `C-k` to delete current alarm
+clock, `g` to refresh the view, and space (`' '`) to turn off
+a ringing alarm (M-x alarm-clock-stop).
+
+### `alarm-clock-stop`
+
+Turn off the currently ringing alarm.
 
 ### `alarm-clock-save`
 
@@ -44,13 +50,33 @@ Save alarm-clock to cache file.
 
 Restore alarm-clock from cache file.
 
+## Enhancements
+
+This fork of
+[wlemuel/alarm-clock](https://github.com/wlemuel/alarm-clock) add these
+features:
+
+-   Allow repeating the alarm clock sound multiple times,
+    asynchornously, or until stopped via M-x alarm-clock-stop
+    or by pressing the SPACE key in the alarm list window.
+-   Allow alarm-clock-list-view to work even if there are no alarms,
+    to allow using `a` to create a new one or SPACE to stop a ringing
+    alarm.
+-   Show time remaining until the alarm fires in the alarm list view.
+    Press `g` to refresh (and update the time remaining).
+-   Aligned the header-line-format with content
+-   New customization variables in the `alarm-clock` group:
+    - `alarm-clock-play-sound-repeat`: Number of times to repeat the
+      sound when an alarm rings. Use M-x alarm-clock-stop to quiet the alarm.
+    - `alarm-clock-play-auto-view-alarms`: If non-nil, display the alarm
+    clock list when ringing an alarm, to allow using SPACE to run alarm-clock-stop
+
 ## Configurations
 
 ### Enable autosave-and-restore feature
 
--   Change cache file path by setting the variable `alarm-clock-cache-file` to any file path you like.  
-
--   Add these lines to your .emacs file:
+-   Change cache file path by setting the variable `alarm-clock-cache-file` to any file path you like.
+-   Add these lines to your `.emacs` file:
 
           (alarm-clock--turn-autosave-on)
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This fork of
     alarm.
 -   Show time remaining until the alarm fires in the alarm list view. Press `g` to refresh.
 -   Aligned the header-line-format with content
+-   Sort alarms by time in alarm-clock-list-view
 -   New customization variables in the `alarm-clock` group:
     - `alarm-clock-play-sound-repeat`: Number of times to repeat the
       sound when an alarm rings. Default is 1. Use M-x alarm-clock-stop

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Derived from [wlemuel/alarm-clock](https://github.com/wlemuel/alarm-clock).
 ## Requirements
 
 -   Emacs 24 or higher
--   [f](https://stable.melpa.org/#/f) file library; install with `(package-install 'f)
 -   [mpg123](http://mpg123.org) (gnu/linux)
 -   [terminal-notifier](https://github.com/julienXX/terminal-notifier) (macOS)
 -   [notify-send](https://manpages.debian.org/stretch/libnotify-bin/notify-send.1.en.html) (gnu/linux)

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ Restore alarm-clock from cache file.
 ## Enhancements
 
 This fork of
-[wlemuel/alarm-clock](https://github.com/wlemuel/alarm-clock) add these
-features:
+[wlemuel/alarm-clock](https://github.com/wlemuel/alarm-clock) adds these features:
 
 -   Allow repeating the alarm clock sound multiple times,
     asynchornously, or until stopped via M-x alarm-clock-stop
@@ -61,12 +60,12 @@ features:
 -   Allow alarm-clock-list-view to work even if there are no alarms,
     to allow using `a` to create a new one or SPACE to stop a ringing
     alarm.
--   Show time remaining until the alarm fires in the alarm list view.
-    Press `g` to refresh (and update the time remaining).
+-   Show time remaining until the alarm fires in the alarm list view. Press `g` to refresh.
 -   Aligned the header-line-format with content
 -   New customization variables in the `alarm-clock` group:
     - `alarm-clock-play-sound-repeat`: Number of times to repeat the
-      sound when an alarm rings. Use M-x alarm-clock-stop to quiet the alarm.
+      sound when an alarm rings. Default is 1. Use M-x alarm-clock-stop
+      to stop ringing the alarm.
     - `alarm-clock-play-auto-view-alarms`: If non-nil, display the alarm
     clock list when ringing an alarm, to allow using SPACE to run alarm-clock-stop
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ This fork of
       to stop ringing the alarm.
     - `alarm-clock-play-auto-view-alarms`: If non-nil, display the alarm
     clock list when ringing an alarm, to allow using SPACE to run alarm-clock-stop
+-   Change alarm-clock-save to use find-file-noselect/save-buffer so that
+    we have ~ backups of the save file
+-   Added alarm-clock--unexpired-alarms
+-   Renamed from alarm-clock--turn-autosave-?? to alarm-clock-turn-autosave-??
+    since they need not be internal function.
+-   Improved doc strings on alarm-clock-turn-autosave-on / alarm-clock-turn-autosave-off
 
 ## Configurations
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,12 @@ This fork of
     asynchornously, or until stopped via M-x alarm-clock-stop
     or by pressing the SPACE key in the alarm list window.
 -   Allow alarm-clock-list-view to work even if there are no alarms,
-    to allow using `a` to create a new one or SPACE to stop a ringing
-    alarm.
+-   Bind `i` and `+` to alarm-clock-set
+-   Bind `-` to alarm-clock-delete
+-   Bind SPACE to stop alarm-clock-stop
 -   Show time remaining until the alarm fires in the alarm list view. Press `g` to refresh.
 -   Aligned the header-line-format with content
--   Sort alarms by time in alarm-clock-list-view
+-   Sort alarms by increasing time (earliest first) in alarm-clock-list-view
 -   New customization variables in the `alarm-clock` group:
     - `alarm-clock-play-sound-repeat`: Number of times to repeat the
       sound when an alarm rings. Default is 1. Use M-x alarm-clock-stop

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -94,6 +94,8 @@
   (define-key alarm-clock-mode-map "d" 'alarm-clock-kill)
   (define-key alarm-clock-mode-map "a" 'alarm-clock-set)
   (define-key alarm-clock-mode-map "i" 'alarm-clock-set)
+  (define-key alarm-clock-mode-map "+" 'alarm-clock-set)
+  (define-key alarm-clock-mode-map "-" 'alarm-clock-delete)
   (define-key alarm-clock-mode-map "g" 'alarm-clock-list-view)
   (define-key alarm-clock-mode-map " " 'alarm-clock-stop)
   )

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -142,7 +142,7 @@ MESSAGE will be shown when notifying in the status bar."
   (let* ((format "%-20s %-12s   %s")
          (inhibit-read-only t) )
     (erase-buffer)
-    (setq header-line-format (format format " Time" " Remaining" " Message  (Press SPACE to stop a ringing alarm)"))
+    (setq header-line-format (format format " Time" " Remaining" " Message"))
     (dolist (alarm (alarm-clock--sort-list))
       (let* ((alarm-time (plist-get alarm :time))
              (alarm-message (plist-get alarm :message))

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -269,7 +269,7 @@ and 'mpg123' in linux"
 (defun alarm-clock-save ()
   "Save alarm clocks to the alarm clock cache file."
   (interactive)
-  (let ((alarm-clocks (maplist (lambda (alarm) (list :time (format-time-string "%FT%T%z" (plist-get alarm :time))
+  (let ((alarm-clocks (seq-map (lambda (alarm) (list :time (format-time-string "%FT%T%z" (plist-get alarm :time))
                                                      :message (plist-get alarm :message)))
                                (alarm-clock--unexpired-alarms))))
     (with-current-buffer (find-file-noselect alarm-clock-cache-file)

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -93,6 +93,7 @@
   (define-key alarm-clock-mode-map [(control k)] 'alarm-clock-kill)
   (define-key alarm-clock-mode-map "d" 'alarm-clock-kill)
   (define-key alarm-clock-mode-map "a" 'alarm-clock-set)
+  (define-key alarm-clock-mode-map "i" 'alarm-clock-set)
   (define-key alarm-clock-mode-map "g" 'alarm-clock-list-view)
   (define-key alarm-clock-mode-map " " 'alarm-clock-stop)
   )
@@ -124,6 +125,13 @@ MESSAGE will be shown when notifying in the status bar."
   (alarm-clock--list-prepare)
   (pop-to-buffer "*alarm clock*"))
 
+(defun alarm-clock--sort-list ()
+  "Sort the alarm in increasing time"
+  (sort alarm-clock--alist (lambda (a b)
+                             (let* ((time-a (plist-get a :time))
+                                    (time-b (plist-get b :time)))
+                               (time-less-p time-b time-a)))))
+
 (defun alarm-clock--list-prepare ()
   "Prefare the list buffer."
   (alarm-clock--cleanup)
@@ -133,7 +141,7 @@ MESSAGE will be shown when notifying in the status bar."
          (inhibit-read-only t) )
     (erase-buffer)
     (setq header-line-format (format format " Time" " Remaining" " Message  (Press SPACE to stop a ringing alarm)"))
-    (dolist (alarm alarm-clock--alist)
+    (dolist (alarm (alarm-clock--sort-list))
       (let* ((alarm-time (plist-get alarm :time))
              (alarm-message (plist-get alarm :message))
              ;; I think alarms are removed from the list when they fire, so no negative remaining values

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -125,18 +125,30 @@ raise an error rather than schedule an alarm that will trigger immediately."
   (unless (timer-duration time)
     ;; time parsing swiped from timer.el run-at-time function in Emacs 27.1
     (require 'diary-lib)
-    (let ((hhmm (diary-entry-time time))
-	  (now (decode-time))
-          then)
-      (wnen (>= hhmm 0)
-	    (setq then
-		  (encode-time 0 (% hhmm 100) (/ hhmm 100)
-                               (decoded-time-day now)
-			       (decoded-time-month now)
-                               (decoded-time-year now)
-                               (decoded-time-zone now)))
-            (and (time-less-p (decode-time then) now)
-                 (error "Time is in the past. Try again")))))
+    (let* ((hhmm (diary-entry-time time))
+           (hh (/ hhmm 100))
+           (mm (% hhmm 100))
+	   (now (decode-time))
+           (hh-now (decoded-time-hour now))
+           (mm-now (decoded-time-minute now))
+           then)
+      (when (>= hhmm 0)
+	;; (setq then (decode-time (encode-time 0
+        ;;                                      (% hhmm 100)
+        ;;                                      (/ hhmm 100)
+        ;;                                      (decoded-time-day now)
+	;; 		                        (decoded-time-month now)
+        ;;                                      (decoded-time-year now)
+        ;;                                      (decoded-time-zone now))))
+        ;; (message "event time %s" then)
+        ;; (message "now        %s" now)
+        ;; time-less-p seems to not work... so compare hh and mm fields
+        ;; (and (time-less-p then nil) ;; nil is current time
+        ;;       (error "Time is in the past. Try again")))))
+        (if (or (< hh hh-now)
+                (and (= hh hh-now)
+                     (< mm mm-now)))
+            (error "Time is in the past. Try again")))))
   time
   )
 

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -59,7 +59,7 @@
   :group 'alarm-clock)
 
 (defcustom alarm-clock-play-auto-view-alarms nil
-  "If non-nul, display the alarm clock list when ringing an alarm, to allow using SPACE to run alarm-clock-stop"
+  "If non-nil, display the alarm clock list when ringing an alarm, to allow using SPACE to run alarm-clock-stop"
   :type 'boolean
   :group 'alarm-clock)
 

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -117,6 +117,7 @@ Auto-save the alarms if alarm-clock-auto-save is true."
 
 (defun alarm-clock--set (time message)
   "Set an alarm clock at time TIME.
+TIME is specified as with the run-at-time function.
 MESSAGE will be shown when notifying in the status bar."
   (interactive "sAlarm at (e.g: 10:00am, 2 minutes, 30 seconds): \nsMessage: ")
   (let* ((time (if (stringp time) (string-trim time) time))

--- a/alarm-clock.el
+++ b/alarm-clock.el
@@ -103,6 +103,8 @@
   (define-key alarm-clock-mode-map "-" 'alarm-clock-kill)
   (define-key alarm-clock-mode-map "g" 'alarm-clock-list-view)
   (define-key alarm-clock-mode-map " " 'alarm-clock-stop)
+  (define-key alarm-clock-mode-map "S" 'alarm-clock-save)
+  (define-key alarm-clock-mode-map "R" 'alarm-clock-restore)
   )
 
 ;;;###autoload


### PR DESCRIPTION
reject times that are in the past

improve layout and formatting of the header line, and set fringe to 0 so data lines line up under headers